### PR TITLE
Drop unused ASM dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
 			<artifactId>json-smart</artifactId>
 			<version>2.2.1</version>
 		</dependency>
-		<dependency>
-			<groupId>net.minidev</groupId>
-			<artifactId>asm</artifactId>
-			<version>1.0.2</version>
-		</dependency>
 
 	</dependencies>
 

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -19,7 +19,6 @@
             <includes>
                 <include>com.jayway.jsonpath:json-path:jar</include>
                 <include>net.minidev:json-smart:jar</include>
-                <include>net.minidev:asm:jar</include>
             </includes>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
             <outputDirectory></outputDirectory>


### PR DESCRIPTION
This plugin doesn't seem to require this dependency. (If I'm wrong about this, let's see whether we can use `org.ow2.asm:asm` instead; that artifact defines a subset of the classes and is also used in our internal build.)